### PR TITLE
Fix 'Nil in String context' and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/packages/
+/META.list

--- a/meta2rpm.pl6
+++ b/meta2rpm.pl6
@@ -17,10 +17,9 @@ multi MAIN(:$module!) {
     my @sources =
         'https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json',
         'https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json';
-    my @source-metas = @sources.map({ from-json run(<curl -->, $_, :out).out.slurp-rest }).flat;
-    my @all-metas = @source-metas.map(*.list).flat
+    my @source-metas = @sources.map({ from-json run(<curl -->, $_, :out).out.slurp }).flat
         .sort: { Version.new($^a<version>) <=> Version.new($^b<version>) };
-    my %metas = @all-metas.map: {$_<name> => $_};
+    my %metas = @source-metas.map: {$_<name> => $_};
 
     sub recursively-create-spec-files($module) {
         my $meta = %metas{$module};


### PR DESCRIPTION
Coerce the hash to list yields an array with (Key => Value).Str items. Sort failed with:
> Use of Nil in string context
>  in sub MAIN at ./meta2rpm.pl6 line 23

My next step will be to move the code into its own package and add tests for them.
