### PR TITLE
Move code in its own module and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /packages/
 /META.list
+.precomp
+.idea/

--- a/META6.json
+++ b/META6.json
@@ -1,0 +1,16 @@
+{
+  "name": "RpmSpecMaker",
+  "description": "Write me!",
+  "version": "0.1",
+  "perl": "6.*",
+  "auth": "Write me!",
+  "depends": [],
+  "build-depends": [],
+  "test-depends": [],
+  "provides": {
+    "RpmSpecMaker": "lib/RpmSpecMaker.pm6"
+  },
+  "resources": [],
+  "license": "Write me!",
+  "source-url": "Write me!"
+}

--- a/META6.json
+++ b/META6.json
@@ -4,10 +4,14 @@
   "version": "0.1",
   "perl": "6.*",
   "auth": "Write me!",
-  "depends": [],
+  "depends": [
+    "JSON::Fast",
+    "File::Temp"
+  ],
   "build-depends": [],
   "test-depends": [],
   "provides": {
+    "meta2rpm": "meta2rpm.pl",
     "RpmSpecMaker": "lib/RpmSpecMaker.pm6"
   },
   "resources": [],

--- a/lib/RpmSpecMaker.pm6
+++ b/lib/RpmSpecMaker.pm6
@@ -10,10 +10,6 @@ module RpmSpecMaker {
         return "perl6-{ $meta<name>.subst: /'::'/, '-', :g }";
     }
 
-    sub get-directory($package-name --> IO::Path) is export {
-        return "packages/$package-name".IO;
-    }
-
     multi sub generate-spec(Hash :$meta!, IO::Path :$package-dir! --> Str) is export {
         die "$package-dir does not exists" unless $package-dir.e;
 

--- a/lib/RpmSpecMaker.pm6
+++ b/lib/RpmSpecMaker.pm6
@@ -14,18 +14,18 @@ module RpmSpecMaker {
         return "packages/$package-name".IO;
     }
 
-    multi sub generate-spec($meta --> Str) is export {
+    multi sub generate-spec(Hash :$meta!, IO::Path :$package-dir! --> Str) is export {
+        die "$package-dir does not exists" unless $package-dir.e;
+
         my $package-name = get-name($meta);
         my $version = $meta<version> eq '*' ?? '0.1' !! $meta<version>;
         my $source-url = $meta<source-url> || $meta<support><source>;
         $meta<license> //= '';
 
-        my $dir = get-directory($package-name);
         my $source-dir = "{$package-name}-$version";
         my $tar-name = "{$package-name}-$version.tar.xz";
 
-        die "$dir does not exists" unless $dir.e;
-        my @files = fetch-source(:$package-name, :$source-url, :$source-dir, :$dir, :$tar-name);
+        my @files = fetch-source(:$package-name, :$source-url, :$source-dir, dir => $package-dir, :$tar-name);
         my $license-file = @files.grep({$_ eq 'LICENSE' or $_ eq 'LICENCE'}).first // '';
 
         return fill-template(

--- a/lib/RpmSpecMaker.pm6
+++ b/lib/RpmSpecMaker.pm6
@@ -140,7 +140,7 @@ module RpmSpecMaker {
         my $LICENSE = $license-file ?? "\n%license $license-file" !! '';
         my $RPM_BUILD_ROOT = '$RPM_BUILD_ROOT'; # Workaround for https://rt.perl.org/Ticket/Display.html?id=127226
         q:s:to/TEMPLATE/
-                #
+        #
         # spec file for package $package-name
         #
         # Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
@@ -164,7 +164,7 @@ module RpmSpecMaker {
         Summary:        $summary
         Url:            $source-url
         Group:          Development/Languages/Other
-        Source0:        $tar-name
+        Source:         $tar-name
         BuildRequires:  fdupes
         $build-requires
         $requires

--- a/lib/RpmSpecMaker.pm6
+++ b/lib/RpmSpecMaker.pm6
@@ -105,13 +105,15 @@ module RpmSpecMaker {
     }
 
     sub requires(:$meta!) is export {
-        return "Requires:       perl6 >= 2016.12" if not $meta<depends>;
-
         my @requires = 'perl6 >= 2016.12';
-        @requires.append: flat $meta<depends>.map({ map-dependency($_) })
-                if $meta<depends> ~~ Positional;
-        @requires.append: flat $meta<depends><runtime><requires>.map({ map-dependency($_) })
-                if $meta<depends> ~~ Associative;
+
+        if $meta<depends> {
+            @requires.append: flat $meta<depends>.map({ map-dependency($_) })
+                    if $meta<depends> ~~ Positional;
+            @requires.append: flat $meta<depends><runtime><requires>.map({ map-dependency($_) })
+                    if $meta<depends> ~~ Associative;
+        }
+
         return @requires.map({"Requires:       $_"}).join("\n");
     }
 

--- a/lib/RpmSpecMaker.pm6
+++ b/lib/RpmSpecMaker.pm6
@@ -1,0 +1,201 @@
+use JSON::Fast;
+
+module RpmSpecMaker {
+    multi sub generate-spec(Str $meta-text) is export {
+        my $meta = from-json($meta-text);
+        callwith($meta);
+    }
+
+    sub get-name($meta) is export {
+        return "perl6-{ $meta<name>.subst: /'::'/, '-', :g }";
+    }
+
+    sub get-directory($package-name --> IO::Path) is export {
+        return "packages/$package-name".IO;
+    }
+
+    multi sub generate-spec($meta --> Str) is export {
+        my $package-name = get-name($meta);
+        my $version = $meta<version> eq '*' ?? '0.1' !! $meta<version>;
+        my $source-url = $meta<source-url> || $meta<support><source>;
+        $meta<license> //= '';
+
+        my $dir = get-directory($package-name);
+        my $source-dir = "{$package-name}-$version";
+        my $tar-name = "{$package-name}-$version.tar.xz";
+
+        die "$dir does not exists" unless $dir.e;
+        my @files = fetch-source(:$package-name, :$source-url, :$source-dir, :$dir, :$tar-name);
+        my $license-file = @files.grep({$_ eq 'LICENSE' or $_ eq 'LICENCE'}).first // '';
+
+        return fill-template(
+            :$meta,
+                :$package-name,
+                :$version,
+                :$tar-name,
+                :$source-url,
+                :$license-file,
+            );
+    }
+
+    sub fetch-source(:$package-name!, :$source-url!, :$source-dir!, IO::Path :$dir!, :$tar-name! --> Seq) is export {
+        if not $source-url {
+            note "$package-name does not have a source-url!";
+            return;
+        }
+
+        if $source-url.starts-with('git://') or $source-url.ends-with('.git') {
+            run <git clone>, $source-url, "$dir/$source-dir" unless $dir.add($source-dir).e;
+            run <tar --exclude=.git -cJf>, $tar-name, $source-dir, :cwd($dir) unless $dir.add($tar-name).e;
+        }
+        else {
+            run 'curl', $source-url, '-o', "$dir/$tar-name" unless $dir.add($tar-name).e;
+            run 'tar', 'xf', $tar-name, :cwd($dir);
+
+            my @top-level-dirs = $dir.dir.grep(* ~~ :d);
+            die "Too many top level directories: @top-level-dirs" if @top-level-dirs.elems != 1;
+            my $top-level-dir = @top-level-dirs[0].basename;
+
+            "$dir/$top-level-dir".IO.rename("$dir/$source-dir");
+            run 'tar', 'cJf', $tar-name, $source-dir, :cwd($dir);
+        }
+
+        return run(<tar tf>, "$dir/$tar-name", :out).out.lines.map(*.substr($source-dir.chars + 1));
+
+        CATCH {
+            default {
+                note "Failed to fetch $source-url";
+                .rethrow;
+            }
+        }
+    }
+
+    sub provides(:$meta!) is export {
+        my @provides;
+        return ($meta<name>, |$meta<provides>.keys).unique.sort.map({"Provides:       perl6($_)"}).join("\n");
+    }
+
+    sub map-dependency($requires is copy) is export {
+        my %adverbs = flat ($requires ~~ s:g/':' $<key> = (\w+) '<' $<value> = (<-[>]>+) '>'//)
+                .map({$_<key>.Str, $_<value>.Str});
+        given %adverbs<from> {
+            when 'native' {
+                if %adverbs<ver> {
+                    my $lib = $*VM.platform-library-name($requires.IO, :version(Version.new(%adverbs<ver>)));
+                    my $path = </usr/lib64 /lib64 /usr/lib /lib>.first({$_.IO.add($lib).e});
+                    if $path {
+                        my $proc = run '/usr/lib/rpm/find-provides', :in, :out;
+                        $proc.in.say($path.IO.add($lib).resolve.Str);
+                        $proc.in.close;
+                        $proc.out.lines;
+                    }
+                    else {
+                        note "Falling back to depending on the library path as I couldn't find $lib";
+                        '%{_libdir}/' ~ $*VM.platform-library-name($requires.IO)
+                    }
+                }
+                else {
+                    note "Package doesn't specify a library version, so I have to fall back to depending on library path.";
+                    '%{_libdir}/' ~ $*VM.platform-library-name($requires.IO)
+                }
+            }
+            when 'bin'    { '%{_bindir}/' ~ $requires }
+            default       { "perl6($requires)" }
+        }
+    }
+
+    sub requires(:$meta!) is export {
+        my @requires = 'perl6 >= 2016.12';
+        @requires.append: flat $meta<depends>.map({ map-dependency($_) })
+                if $meta<depends> and $meta<depends> ~~ Positional;
+        @requires.append: flat $meta<depends><runtime><requires>.map({ map-dependency($_) })
+                if $meta<depends> and $meta<depends> ~~ Associative;
+        return @requires.map({"Requires:       $_"}).join("\n");
+    }
+
+    sub build-requires(:$meta!) is export {
+        my @requires = 'rakudo >= 2017.04.2';
+        @requires.append: flat $meta<depends>.map({ map-dependency($_) })
+                if $meta<depends> and $meta<depends> ~~ Positional;
+        @requires.append: flat $meta<depends><build><requires>.map({ map-dependency($_) })
+                if $meta<depends> and $meta<depends> ~~ Associative;
+        @requires.append: flat $meta<build-depends>.map({ map-dependency($_) })
+                if $meta<build-depends>;
+        @requires.push: 'Distribution::Builder' ~ $meta<builder> if $meta<builder>;
+        return @requires.map({"BuildRequires:  $_"}).join("\n");
+    }
+
+    sub fill-template(:$meta!, :$package-name!, :$tar-name!, :$version!, :$source-url!, :$license-file!) is export {
+        my $provides = provides(:$meta);
+        my $requires = requires(:$meta);
+        my $build-requires = build-requires(:$meta);
+        my $summary = $meta<description>;
+        $summary.=chop if $summary and $summary.ends-with('.');
+        my $LICENSE = $license-file ?? "\n%license $license-file" !! '';
+        my $RPM_BUILD_ROOT = '$RPM_BUILD_ROOT'; # Workaround for https://rt.perl.org/Ticket/Display.html?id=127226
+        q:s:to/TEMPLATE/
+                #
+        # spec file for package $package-name
+        #
+        # Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
+        #
+        # All modifications and additions to the file contributed by third parties
+        # remain the property of their copyright owners, unless otherwise agreed
+        # upon. The license for this file, and modifications and additions to the
+        # file, is the same license as for the pristine package itself (unless the
+        # license for the pristine package is not an Open Source License, in which
+        # case the license is the MIT License). An "Open Source License" is a
+        # license that conforms to the Open Source Definition (Version 1.9)
+        # published by the Open Source Initiative.
+
+        # Please submit bugfixes or comments via http://bugs.opensuse.org/
+        #
+
+        Name:           $package-name
+        Version:        $version
+        Release:        1.1
+        License:        $meta<license>
+        Summary:        $summary
+        Url:            $source-url
+        Group:          Development/Languages/Other
+        Source0:        $tar-name
+        BuildRequires:  fdupes
+        $build-requires
+        $requires
+        $provides
+        BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+        %description
+        $summary
+
+        %prep
+        %setup -q
+
+        %build
+
+        %install
+        RAKUDO_MODULE_DEBUG=1 RAKUDOE_PRECOMP_VERBOSE=1 RAKUDO_RERESOLVE_DEPENDENCIES=0 raku --ll-exception %{_datadir}/perl6/bin/install-perl6-dist \\
+                --to=$RPM_BUILD_ROOT%{_datadir}/perl6/vendor \\
+                --for=vendor \\
+                --from=.
+        %fdupes %{buildroot}/%{_datadir}/perl6/vendor
+
+        rm -f %{buildroot}%{_datadir}/perl6/vendor/bin/*-j
+        rm -f %{buildroot}%{_datadir}/perl6/vendor/bin/*-js
+        find %{buildroot}/%{_datadir}/perl6/vendor/bin/ -type f -exec sed -i -e '1s:!/usr/bin/env :!/usr/bin/:' '{}' \;
+
+        %files
+        %defattr(-,root,root)
+        %doc README.md$LICENSE
+        %{_datadir}/perl6/vendor
+
+        %changelog
+        TEMPLATE
+    }
+
+    =begin comment
+    When collecting a tar file not in git the file name may not be correct.
+    To resolve this we will pack trhe file and then repack it with file name and configuration we want.
+    =end comment
+
+}

--- a/meta2rpm.pl6
+++ b/meta2rpm.pl6
@@ -28,7 +28,7 @@ multi MAIN(:$module!) {
     my @sources =
         'https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json',
         'https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json';
-    my @source-metas = @sources.map({ from-json run(<curl -->, $_, :out).out.slurp }).flat
+    my @source-metas = @sources.map({ say "Fetch: $_"; from-json run(<curl -s -->, $_, :out).out.slurp }).flat
         .sort: { Version.new($^a<version>) <=> Version.new($^b<version>) };
     my %metas = @source-metas.map: {$_<name> => $_};
 

--- a/meta2rpm.pl6
+++ b/meta2rpm.pl6
@@ -1,4 +1,5 @@
 use JSON::Fast;
+use lib 'lib';
 
 use RpmSpecMaker;
 
@@ -56,10 +57,9 @@ multi MAIN(:$module!) {
 
 sub create-spec-file($meta) {
     my $package-name = get-name($meta);
-    my $package-dir = get-directory($package-name);
 
-    $package-dir.mkdir;
-    my $spec = generate-spec($meta);
+    my $package-dir = "./packages".IO.add($package-name).mkdir;
+    my $spec = generate-spec(:$meta, :$package-dir);
     $package-dir.add($package-name ~ ".spec").spurt($spec);
 }
 

--- a/meta2rpm.pl6
+++ b/meta2rpm.pl6
@@ -1,16 +1,27 @@
 use JSON::Fast;
 
+use RpmSpecMaker;
+
 multi MAIN() {
     for "META.list".IO.lines -> $uri {
         my $request = run 'curl', '-s', $uri, :out;
-        my $meta-text = $request.out.slurp;
-        create-spec-file($meta-text);
+        my $meta;
+
+        try {
+            $meta = from-json($request.out.slurp);
+            CATCH {
+                default {
+                    note "Could not find meta as json from $uri";
+                    next;
+                }
+            }
+        }
+            create-spec-file($meta);
     }
 }
 
 multi MAIN($meta-file) {
-    my $meta-text = $meta-file.IO.slurp;
-    create-spec-file($meta-text);
+    create-spec-file(from-json($meta-file.IO.slurp));
 }
 
 multi MAIN(:$module!) {
@@ -27,7 +38,9 @@ multi MAIN(:$module!) {
             note "Did not find META for $module!";
             next;
         }
+
         create-spec-file($meta);
+
         my @requires;
         @requires.append: flat $meta<depends>.map({ map-dependency($_) }) if $meta<depends>;
         @requires.append: flat $meta<build-depends>.map({ map-dependency($_) }) if $meta<build-depends>;
@@ -41,197 +54,14 @@ multi MAIN(:$module!) {
     recursively-create-spec-files($module);
 }
 
-multi sub create-spec-file(Str $meta-text) {
-    my $meta = from-json($meta-text);
-    callwith($meta);
+sub create-spec-file($meta) {
+    my $package-name = get-name($meta);
+    my $package-dir = get-directory($package-name);
+
+    $package-dir.mkdir;
+    my $spec = generate-spec($meta);
+    $package-dir.add($package-name ~ ".spec").spurt($spec);
 }
-
-multi sub create-spec-file($meta) {
-    my $package-name = "perl6-{ $meta<name>.subst: /'::'/, '-', :g }";
-    note $package-name;
-    my $version = $meta<version> eq '*' ?? '0.1' !! $meta<version>;
-    my $source-url = $meta<source-url> || $meta<support><source>;
-    $meta<license> //= '';
-
-    my $dir = "packages/$package-name".IO;
-    my $source-dir = "{$package-name}-$version";
-    my $tar-name = "{$package-name}-$version.tar.xz";
-
-    mkdir $dir;
-    my @files = fetch-source(:$package-name, :$source-url, :$source-dir, :$dir, :$tar-name);
-    my $license-file = @files.grep({$_ eq 'LICENSE' or $_ eq 'LICENCE'}).first // '';
-
-    $dir.IO.child("$package-name.spec").spurt:
-        fill-template(
-            :$meta,
-            :$package-name,
-            :$version,
-            :$tar-name,
-            :$source-url,
-            :$license-file,
-        );
-}
-
-sub fetch-source(:$package-name!, :$source-url!, :$source-dir!, IO::Path :$dir!, :$tar-name! --> Seq) {
-        if $source-url {
-            if $source-url.starts-with('git://') or $source-url.ends-with('.git') {
-                run <git clone>, $source-url, "$dir/$source-dir" unless $dir.add($source-dir).e;
-                run <tar --exclude=.git -cJf>, $tar-name, $source-dir, :cwd($dir) unless $dir.add($tar-name).e;
-            }
-            else {
-                run 'wget', '-q', $source-url, '-O', "$dir/$tar-name" unless $dir.add($tar-name).e;
-                run 'tar', 'xf', $tar-name, :cwd($dir);
-
-                my @top-level-dirs = $dir.dir.grep(* ~~ :d);
-                die "Too many top level directories: @top-level-dirs" if @top-level-dirs.elems != 1;
-                my $top-level-dir = @top-level-dirs[0].basename;
-
-                "$dir/$top-level-dir".IO.rename("$dir/$source-dir");
-                run 'tar', 'cJf', $tar-name, $source-dir, :cwd($dir);
-            }
-            return run(<tar tf>, "$dir/$tar-name", :out).out.lines.map(*.substr($source-dir.chars + 1));
-            CATCH {
-                default {
-                    note "Failed to fetch $source-url";
-                    .rethrow;
-                }
-            }
-
-        }
-        else {
-            note "$package-name does not have a source-url!";
-        }
-        return;
-}
-
-sub provides(:$meta!) {
-    my @provides;
-    return ($meta<name>, |$meta<provides>.keys).sort.map({"Provides:       perl6($_)"}).join("\n");
-}
-
-sub map-dependency($requires is copy) {
-    my %adverbs = flat ($requires ~~ s:g/':' $<key> = (\w+) '<' $<value> = (<-[>]>+) '>'//)
-        .map({$_<key>.Str, $_<value>.Str});
-    given %adverbs<from> {
-        when 'native' {
-            if %adverbs<ver> {
-                my $lib = $*VM.platform-library-name($requires.IO, :version(Version.new(%adverbs<ver>)));
-                my $path = </usr/lib64 /lib64 /usr/lib /lib>.first({$_.IO.add($lib).e});
-                if $path {
-                    my $proc = run '/usr/lib/rpm/find-provides', :in, :out;
-                    $proc.in.say($path.IO.add($lib).resolve.Str);
-                    $proc.in.close;
-                    $proc.out.lines;
-                }
-                else {
-                    note "Falling back to depending on the library path as I couldn't find $lib";
-                    '%{_libdir}/' ~ $*VM.platform-library-name($requires.IO)
-                }
-            }
-            else {
-                note "Package doesn't specify a library version, so I have to fall back to depending on library path.";
-                '%{_libdir}/' ~ $*VM.platform-library-name($requires.IO)
-            }
-        }
-        when 'bin'    { '%{_bindir}/' ~ $requires }
-        default       { "perl6($requires)" }
-    }
-}
-
-sub requires(:$meta!) {
-    my @requires = 'perl6 >= 2016.12';
-    @requires.append: flat $meta<depends>.map({ map-dependency($_) })
-        if $meta<depends> and $meta<depends> ~~ Positional;
-    @requires.append: flat $meta<depends><runtime><requires>.map({ map-dependency($_) })
-        if $meta<depends> and $meta<depends> ~~ Associative;
-    return @requires.map({"Requires:       $_"}).join("\n");
-}
-
-sub build-requires(:$meta!) {
-    my @requires = 'rakudo >= 2017.04.2';
-    @requires.append: flat $meta<depends>.map({ map-dependency($_) })
-        if $meta<depends> and $meta<depends> ~~ Positional;
-    @requires.append: flat $meta<depends><build><requires>.map({ map-dependency($_) })
-        if $meta<depends> and $meta<depends> ~~ Associative;
-    @requires.append: flat $meta<build-depends>.map({ map-dependency($_) })
-        if $meta<build-depends>;
-    @requires.push: 'Distribution::Builder' ~ $meta<builder> if $meta<builder>;
-    return @requires.map({"BuildRequires:  $_"}).join("\n");
-}
-
-sub fill-template(:$meta!, :$package-name!, :$tar-name!, :$version!, :$source-url!, :$license-file!) {
-    my $provides = provides(:$meta);
-    my $requires = requires(:$meta);
-    my $build-requires = build-requires(:$meta);
-    my $summary = $meta<description>;
-    $summary.=chop if $summary and $summary.ends-with('.');
-    my $LICENSE = $license-file ?? "\n%license $license-file" !! '';
-    my $RPM_BUILD_ROOT = '$RPM_BUILD_ROOT'; # Workaround for https://rt.perl.org/Ticket/Display.html?id=127226
-    q:s:to/TEMPLATE/
-        #
-        # spec file for package $package-name
-        #
-        # Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
-        #
-        # All modifications and additions to the file contributed by third parties
-        # remain the property of their copyright owners, unless otherwise agreed
-        # upon. The license for this file, and modifications and additions to the
-        # file, is the same license as for the pristine package itself (unless the
-        # license for the pristine package is not an Open Source License, in which
-        # case the license is the MIT License). An "Open Source License" is a
-        # license that conforms to the Open Source Definition (Version 1.9)
-        # published by the Open Source Initiative.
-        
-        # Please submit bugfixes or comments via http://bugs.opensuse.org/
-        #
-
-        Name:           $package-name
-        Version:        $version
-        Release:        1.1
-        License:        $meta<license>
-        Summary:        $summary
-        Url:            $source-url
-        Group:          Development/Languages/Other
-        Source0:        $tar-name
-        BuildRequires:  fdupes
-        $build-requires
-        $requires
-        $provides
-        BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-
-        %description
-        $summary
-
-        %prep
-        %setup -q
-
-        %build
-
-        %install
-        RAKUDO_MODULE_DEBUG=1 RAKUDOE_PRECOMP_VERBOSE=1 RAKUDO_RERESOLVE_DEPENDENCIES=0 raku --ll-exception %{_datadir}/perl6/bin/install-perl6-dist \\
-                --to=$RPM_BUILD_ROOT%{_datadir}/perl6/vendor \\
-                --for=vendor \\
-                --from=.
-        %fdupes %{buildroot}/%{_datadir}/perl6/vendor
-
-        rm -f %{buildroot}%{_datadir}/perl6/vendor/bin/*-j
-        rm -f %{buildroot}%{_datadir}/perl6/vendor/bin/*-js
-        find %{buildroot}/%{_datadir}/perl6/vendor/bin/ -type f -exec sed -i -e '1s:!/usr/bin/env :!/usr/bin/:' '{}' \;
-
-        %files
-        %defattr(-,root,root)
-        %doc README.md$LICENSE
-        %{_datadir}/perl6/vendor
-
-        %changelog
-        TEMPLATE
-}
-
-=begin comment
-When collecting a tar file not in git the file name may not be correct.
-To resolve this we will pack trhe file and then repack it with file name and configuration we want.
-=end comment
-
 
 # vim: ft=perl6
 

--- a/t/RpmSpecMaker.t
+++ b/t/RpmSpecMaker.t
@@ -5,7 +5,7 @@ use File::Temp;
 
 use RpmSpecMaker;
 
-plan 22;
+plan 21;
 
 dies-ok { generate-spec('No valid json') }, "Invalid json dies";
 
@@ -33,9 +33,6 @@ my $valid-json = q:to/END/;
    "version" : "0.0.2"
 }
 END
-
-is get-directory("perl6-IO-Prompt"), "packages/perl6-IO-Prompt", "Package directory found";
-get-directory("perl6-IO-Prompt").mkdir;
 
 lives-ok {generate-spec($valid-json)}, "No exception for valid json string and crated package directory";
 my $meta = from-json($valid-json);

--- a/t/RpmSpecMaker.t
+++ b/t/RpmSpecMaker.t
@@ -45,20 +45,27 @@ is get-name($meta), "perl6-IO-Prompt", "Name found";
 is provides(meta => from-json($valid-json)), "Provides:       perl6(IO::Prompt)", "Provides returns proper string";
 
 is requires(:$meta), "Requires:       perl6 >= 2016.12", "Requires returns one dependency";
-is requires( meta => { depends => ["Method::Also"] }),
-    "Requires:       perl6 >= 2016.12\nRequires:       perl6(Method::Also)",
-    "Requires returns several dependencies";
-is requires( meta => { depends => { runtime => { "requires" => ["Cairo","Color"] } } }),
-    "Requires:       perl6 >= 2016.12\nRequires:       perl6(Cairo)\nRequires:       perl6(Color)",
-    "Requires returns several runtime dependencies";
+is requires( meta => { depends => ["Method::Also"] }), chomp(q:to/SPEC/), "Requires returns several dependencies";
+    Requires:       perl6 >= 2016.12
+    Requires:       perl6(Method::Also)
+    SPEC
+is requires( meta => { depends => { runtime => { "requires" => ["Cairo","Color"] } } }), chomp(q:to/SPEC/), "Requires returns several runtime dependencies";
+    Requires:       perl6 >= 2016.12
+    Requires:       perl6(Cairo)
+    Requires:       perl6(Color)
+    SPEC
 
 is build-requires(:$meta), "BuildRequires:  rakudo >= 2017.04.2", "Build-requires returns one dependency";
-is build-requires(meta => {build-depends =>  ["LibraryMake","Pod::To::Markdown"] } ),
-    "BuildRequires:  rakudo >= 2017.04.2\nBuildRequires:  perl6(LibraryMake)\nBuildRequires:  perl6(Pod::To::Markdown)",
-    "Build-requires returns several dependency";
-is build-requires(meta => {build-depends =>  ["LibraryMake"], depends => { build => { "requires" => ["Pod::To::Markdown"]}} } ),
-    "BuildRequires:  rakudo >= 2017.04.2\nBuildRequires:  perl6(Pod::To::Markdown)\nBuildRequires:  perl6(LibraryMake)",
-    "Build-requires returns also depends dependency";
+is build-requires(meta => {build-depends =>  ["LibraryMake","Pod::To::Markdown"] } ), chomp(q:to/SPEC/), "Build-requires returns several dependency";
+    BuildRequires:  rakudo >= 2017.04.2
+    BuildRequires:  perl6(LibraryMake)
+    BuildRequires:  perl6(Pod::To::Markdown)
+    SPEC
+is build-requires(meta => {build-depends =>  ["LibraryMake"], depends => { build => { "requires" => ["Pod::To::Markdown"]}} } ), chomp(q:to/SPEC/), "Build-requires returns also depends dependency";
+    BuildRequires:  rakudo >= 2017.04.2
+    BuildRequires:  perl6(Pod::To::Markdown)
+    BuildRequires:  perl6(LibraryMake)
+    SPEC
 
 my $package-dir = tempdir().IO;
 my $spec = generate-spec(:$meta, :$package-dir);

--- a/t/RpmSpecMaker.t
+++ b/t/RpmSpecMaker.t
@@ -7,7 +7,7 @@ use RpmSpecMaker;
 rm-directories("packages".IO);
 
 
-plan 12;
+plan 22;
 
 dies-ok { generate-spec('No valid json') }, "Invalid json dies";
 
@@ -65,6 +65,16 @@ is build-requires(meta => {build-depends =>  ["LibraryMake"], depends => { build
 
 my $spec = generate-spec($meta);
 
+like $spec, /'Source:         perl6-IO-Prompt-0.0.2.tar.xz'/, "Source found in spec file";
+like $spec, /'Name:           perl6-IO-Prompt'/, "Name found in spec file";
+like $spec, /'Version:        0.0.2'/, "Version found in spec file";
+like $spec, /'Release:        1.1'/, "Release found in spec file";
+like $spec, /'License:        Artistic-2.0'/, "License found in spec file";
+like $spec, /'BuildRequires:  fdupes'/, "BuildRequires found in spec file";
+like $spec, /'BuildRequires:  fdupes' \n 'BuildRequires:  rakudo >= 2017.04.2'/, "BuildRequires found in spec file";
+like $spec, /'Requires:       perl6 >= 2016.12'/, "Requires found in spec file";
+like $spec, /'Provides:       perl6(IO::Prompt)'/, "Provides found in spec file";
+like $spec, /'BuildRoot:      %{_tmppath}/%{name}-%{version}-build'/, "BuildRoot found in spec file";
 
 sub rm-directories(IO::Path $dir) {
     return unless $dir.e;

--- a/t/RpmSpecMaker.t
+++ b/t/RpmSpecMaker.t
@@ -4,51 +4,75 @@ use JSON::Fast;
 
 use RpmSpecMaker;
 
-subtest {
-    dies-ok { generate-spec('No valid json') }, "Invalid json dies";
-
-    my $valid-json = q:to/END/;
-    {
-       "authors" : [
-          "pnu",
-          "wbiker"
-       ],
-       "build-depends" : [],
-       "depends" : [],
-       "description" : "This is a generic module for interactive prompting from the console.",
-       "license" : "Artistic-2.0",
-       "name" : "IO::Prompt",
-       "perl" : "6.*",
-       "provides" : {
-          "IO::Prompt" : "lib/IO/Prompt.pm"
-       },
-       "resources" : [],
-       "source-url" : "http://www.cpan.org/authors/id/W/WB/WBIKER/Perl6/IO-Prompt-0.0.2.tar.gz",
-       "tags" : [],
-       "test-depends" : [
-          "Test"
-       ],
-       "version" : "0.0.2"
-    }
-    END
-
-    dies-ok { generate-spec($valid-json) }, "Dies without created package directory";
-
-    is get-directory("perl6-IO-Prompt"), "packages/perl6-IO-Prompt", "Package directory found";
-    get-directory("perl6-IO-Prompt").mkdir;
-
-    lives-ok {generate-spec($valid-json)}, "No exception for valid json string and crated package directory";
-    my $meta = from-json($valid-json);
-
-    is get-name($meta), "perl6-IO-Prompt", "Name found";
-    is provides(meta => from-json($valid-json)), "Provides:       perl6(IO::Prompt)", "Provides returns proper string";
-    is requires(:$meta), "Requires:       perl6 >= 2016.12", "Requires returns proper string";
-    is build-requires(:$meta), "BuildRequires:  rakudo >= 2017.04.2", "Build-requires returns proper string";
-
-    my $spec = generate-spec($meta);
+rm-directories("packages".IO);
 
 
-    done-testing
+plan 12;
+
+dies-ok { generate-spec('No valid json') }, "Invalid json dies";
+
+my $valid-json = q:to/END/;
+        {
+   "authors" : [
+      "pnu",
+      "wbiker"
+   ],
+   "build-depends" : [],
+   "depends" : [],
+   "description" : "This is a generic module for interactive prompting from the console.",
+   "license" : "Artistic-2.0",
+   "name" : "IO::Prompt",
+   "perl" : "6.*",
+   "provides" : {
+      "IO::Prompt" : "lib/IO/Prompt.pm"
+   },
+   "resources" : [],
+   "source-url" : "http://www.cpan.org/authors/id/W/WB/WBIKER/Perl6/IO-Prompt-0.0.2.tar.gz",
+   "tags" : [],
+   "test-depends" : [
+      "Test"
+   ],
+   "version" : "0.0.2"
 }
+END
 
-done-testing;
+dies-ok { generate-spec($valid-json) }, "Dies without created package directory";
+
+is get-directory("perl6-IO-Prompt"), "packages/perl6-IO-Prompt", "Package directory found";
+get-directory("perl6-IO-Prompt").mkdir;
+
+lives-ok {generate-spec($valid-json)}, "No exception for valid json string and crated package directory";
+my $meta = from-json($valid-json);
+
+is get-name($meta), "perl6-IO-Prompt", "Name found";
+is provides(meta => from-json($valid-json)), "Provides:       perl6(IO::Prompt)", "Provides returns proper string";
+
+is requires(:$meta), "Requires:       perl6 >= 2016.12", "Requires returns one dependency";
+is requires( meta => { depends => ["Method::Also"] }),
+    "Requires:       perl6 >= 2016.12\nRequires:       perl6(Method::Also)",
+    "Requires returns several dependencies";
+is requires( meta => { depends => { runtime => { "requires" => ["Cairo","Color"] } } }),
+    "Requires:       perl6 >= 2016.12\nRequires:       perl6(Cairo)\nRequires:       perl6(Color)",
+    "Requires returns several runtime dependencies";
+
+is build-requires(:$meta), "BuildRequires:  rakudo >= 2017.04.2", "Build-requires returns one dependency";
+is build-requires(meta => {build-depends =>  ["LibraryMake","Pod::To::Markdown"] } ),
+    "BuildRequires:  rakudo >= 2017.04.2\nBuildRequires:  perl6(LibraryMake)\nBuildRequires:  perl6(Pod::To::Markdown)",
+    "Build-requires returns several dependency";
+is build-requires(meta => {build-depends =>  ["LibraryMake"], depends => { build => { "requires" => ["Pod::To::Markdown"]}} } ),
+    "BuildRequires:  rakudo >= 2017.04.2\nBuildRequires:  perl6(Pod::To::Markdown)\nBuildRequires:  perl6(LibraryMake)",
+    "Build-requires returns also depends dependency";
+
+my $spec = generate-spec($meta);
+
+
+sub rm-directories(IO::Path $dir) {
+    return unless $dir.e;
+
+    for $dir.dir -> $item {
+        rm-directories($item) if $item.d;
+
+        $item.unlink;
+    }
+    $dir.rmdir;
+}

--- a/t/RpmSpecMaker.t
+++ b/t/RpmSpecMaker.t
@@ -1,0 +1,54 @@
+use Test;
+use lib 'lib';
+use JSON::Fast;
+
+use RpmSpecMaker;
+
+subtest {
+    dies-ok { generate-spec('No valid json') }, "Invalid json dies";
+
+    my $valid-json = q:to/END/;
+    {
+       "authors" : [
+          "pnu",
+          "wbiker"
+       ],
+       "build-depends" : [],
+       "depends" : [],
+       "description" : "This is a generic module for interactive prompting from the console.",
+       "license" : "Artistic-2.0",
+       "name" : "IO::Prompt",
+       "perl" : "6.*",
+       "provides" : {
+          "IO::Prompt" : "lib/IO/Prompt.pm"
+       },
+       "resources" : [],
+       "source-url" : "http://www.cpan.org/authors/id/W/WB/WBIKER/Perl6/IO-Prompt-0.0.2.tar.gz",
+       "tags" : [],
+       "test-depends" : [
+          "Test"
+       ],
+       "version" : "0.0.2"
+    }
+    END
+
+    dies-ok { generate-spec($valid-json) }, "Dies without created package directory";
+
+    is get-directory("perl6-IO-Prompt"), "packages/perl6-IO-Prompt", "Package directory found";
+    get-directory("perl6-IO-Prompt").mkdir;
+
+    lives-ok {generate-spec($valid-json)}, "No exception for valid json string and crated package directory";
+    my $meta = from-json($valid-json);
+
+    is get-name($meta), "perl6-IO-Prompt", "Name found";
+    is provides(meta => from-json($valid-json)), "Provides:       perl6(IO::Prompt)", "Provides returns proper string";
+    is requires(:$meta), "Requires:       perl6 >= 2016.12", "Requires returns proper string";
+    is build-requires(:$meta), "BuildRequires:  rakudo >= 2017.04.2", "Build-requires returns proper string";
+
+    my $spec = generate-spec($meta);
+
+
+    done-testing
+}
+
+done-testing;


### PR DESCRIPTION
Unfortunately, this is a rather huge pull request but it contains some bug fixes and a first set of unit tests.

-> Moved code into lib/RpmSpecMaker.pm6.
-> Refactored code to be able to test subs as far as possible.
-> Fix: Replaced "Source0:" with "Source in the spec file template.
-> Added some tests.